### PR TITLE
Use Ubuntu TLS client on Debian

### DIFF
--- a/noble_tls/utils/asset.py
+++ b/noble_tls/utils/asset.py
@@ -58,7 +58,7 @@ def generate_asset_name(
 
         if system_os == 'linux':
             distro_name = get_distro()
-            if distro_name.lower() == "ubuntu":
+            if distro_name.lower() in {"ubuntu", "debian"}:
                 system_os = f"{system_os}-{distro_name}"
 
     return f"{custom_part}-{system_os}-{asset_arch}-v{version}{file_extension}"

--- a/noble_tls/utils/asset.py
+++ b/noble_tls/utils/asset.py
@@ -59,7 +59,7 @@ def generate_asset_name(
         if system_os == 'linux':
             distro_name = get_distro()
             if distro_name.lower() in {"ubuntu", "debian"}:
-                system_os = f"{system_os}-{distro_name}"
+                system_os = f"{system_os}-ubuntu"
 
     return f"{custom_part}-{system_os}-{asset_arch}-v{version}{file_extension}"
 


### PR DESCRIPTION
To avoid the following error when using the library on a Debian machine, it can use the Ubuntu build.
```
>> Dependencies folder is empty. Downloading the latest TLS release...
>> Failed to load the TLS Client asset: Unable to find asset tls-client-linux-amd64-v1.7.2.so for version 1.7.2.
Traceback (most recent call last):
  File "/src/main.py", line 7, in <module>
    import noble_tls
  File "/usr/local/lib/python3.10/site-packages/noble_tls/__init__.py", line 13, in <module>
    from .sessions import Session
  File "/usr/local/lib/python3.10/site-packages/noble_tls/sessions.py", line 9, in <module>
    from .c.cffi import request, free_memory
  File "/usr/local/lib/python3.10/site-packages/noble_tls/c/cffi.py", line 84, in <module>
    request = library.request
AttributeError: 'NoneType' object has no attribute 'request'
```