### PR TITLE
Add support for byte responses

### DIFF
--- a/noble_tls/sessions.py
+++ b/noble_tls/sessions.py
@@ -294,7 +294,8 @@ class Session:
             insecure_skip_verify: Optional[bool] = False,
             timeout_seconds: Optional[int] = None,
             timeout: Optional[int] = None,
-            proxy: Optional[dict] = None  # Optional[dict[str, str]]
+            proxy: Optional[dict] = None,  # Optional[dict[str, str]]
+            is_byte_response: Optional[bool] = False
     ):
 
         # --- Timeout --------------------------------------------------------------------------------------------------
@@ -381,6 +382,7 @@ class Session:
                 "headerOrder": self.header_order,
                 "insecureSkipVerify": insecure_skip_verify,
                 "isByteRequest": is_byte_request,
+                "isByteResponse": is_byte_response,
                 "additionalDecode": self.additional_decode,
                 "proxyUrl": proxy,
                 "requestUrl": url,


### PR DESCRIPTION
This will be useful if you want to get raw bytes from a response, here's a quick example on how to do that.
You can check additional request parameters here: https://github.com/bogdanfinn/tls-client/blob/master/cffi_dist/main.go
```python
    async def perform_request(
        self, 
        session: Session, 
        task: Task,
        url: str
    ):
        return await session.get(
            url=url,
            headers=self.get_headers(),
            allow_redirects=self.get_allow_redirects(),
            proxy=task.get_settings_proxy(),
            is_byte_response=True
        )
```
```python
captcha_response_base64 = captcha_response.text
captcha_response_bytes = base64.b64decode(captcha_response_base64.split(',')[1].encode('utf-8'))
```