### PR TITLE
Add support for Safari_18_5

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ from noble_tls import Client
     SAFARI_IOS_16_0 = "safari_ios_16_0"
     SAFARI_IOS_17_0 = "safari_ios_17_0"
     SAFARI_IOS_18_0 = "safari_ios_18_0"
+    SAFARI_IOS_18_5 = "safari_ios_18_5"
     FIREFOX_102 = "firefox_102"
     FIREFOX_104 = "firefox_104"
     FIREFOX_105 = "firefox_105"

--- a/noble_tls/__version__.py
+++ b/noble_tls/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "noble_tls"
 __description__ = "Advanced TLS/SSL wrapper for Python"
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __author__ = "Rawand Ahmed Shaswar"
 __license__ = "MIT"

--- a/noble_tls/utils/identifiers.py
+++ b/noble_tls/utils/identifiers.py
@@ -29,6 +29,7 @@ class Client(Enum):
     SAFARI_IOS_16_0 = "safari_ios_16_0"
     SAFARI_IOS_17_0 = "safari_ios_17_0"
     SAFARI_IOS_18_0 = "safari_ios_18_0"
+    SAFARI_IOS_18_5 = "safari_ios_18_5"
     FIREFOX_102 = "firefox_102"
     FIREFOX_104 = "firefox_104"
     FIREFOX_105 = "firefox_105"


### PR DESCRIPTION
Support for safari 18_5 recently pushed to tls library : https://github.com/bogdanfinn/tls-client/commit/6499b7c980cf8e9006df013d66604ae5afa099fc 