### PR TITLE
Update cookie request construction with getattr

### DIFF
--- a/noble_tls/sessions.py
+++ b/noble_tls/sessions.py
@@ -352,9 +352,15 @@ class Session:
         # turn cookie jar into dict
         # in the cookie value the " gets removed, because the fhttp library in golang doesn't accept the character
         request_cookies = [
-            {'domain': c.domain, 'expires': c.expires, 'name': c.name, 'path': c.path,
-             'value': c.value.replace('"', "")}
+            {
+                'domain': getattr(c, "domain", ""),
+                'expires': getattr(c, "expires", ""),
+                'name': getattr(c, "name", ""),
+                'path': getattr(c, "path", ""),
+                'value': (getattr(c, "value", "") or "").replace('"', ""),
+            }
             for c in cookies
+            if c is not None
         ]
 
         # --- Proxy ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When setting a null cookie in the session, the code simply crashes and doesn't display a descriptive error.
it simply displays an attribute error.

It might be easy to identify with just a few requests in your session, but over a long session it becomes more difficult to pinpoint where it's happening. It happens even with Python-Tls-Client. I suggest simply avoiding cookies with null values.

<img width="1652" height="184" alt="image" src="https://github.com/user-attachments/assets/056c3c6e-e6f5-4f5b-82b9-278bcd0c4fa4" />
